### PR TITLE
Kick-starting testing:  very basic test based on synthetic, travis, coveralls, tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+# vim ft=yaml
+# travis-ci.org definition for Nimfa tests
+language: python
+
+sudo: false
+
+cache:
+ apt: true
+
+addons:
+  apt:
+    packages:
+      - libatlas3gf-base
+      - libatlas-dev
+      - python-scipy
+
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+
+install:
+  - travis_retry pip install -q coveralls
+  - pip install -r requirements-tests.txt
+  - pip install -e .
+
+script:
+  - py.test nimfa
+  - python setup.py install  # test installation
+
+after_success:
+  - coveralls
+
+# TODO Later if you decide to upload tagged releases to pypi automagically
+# see https://docs.travis-ci.com/user/deployment/pypi/ for details
+#deploy:
+#  provider: pypi
+#  distributions: sdist
+#  user: YOURUSERNAME
+#  password:
+#    secure: YOUR_ENCRYPTED_WITH_TRAVISTOOLS_PASSWORD_FOR_PYPI
+#  on:
+#    tags: true
+#    branch: master
+#    repo: YOURGITHUBLOGIN/nimfa
+#    condition: "$TRAVIS_PYTHON_VERSION == 2.7 && $TRAVIS_TAG =~ ^v[0-9]*[.][.0-9]*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy pytest
   - pip install pep8 python-coveralls pytest-cov
-  - pip install .
+  - pip install -e .
 
 script:
   - py.test --cov=nimfa

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,27 @@ cache:
 addons:
   apt:
     packages:
-      - libatlas3gf-base
-      - libatlas-dev
-      - python-scipy
-
+    - libatlas-dev
+    - libatlas-base-dev
+    - liblapack-dev
 python:
   - "2.7"
   - "3.4"
   - "3.5"
 
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda update --yes conda
+
 install:
-  - travis_retry pip install -q coveralls
-  - pip install -r requirements-tests.txt
-  - pip install -e .
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy pytest
+  - pip install pep8 python-coveralls pytest-cov
+  - pip install .
 
 script:
-  - py.test nimfa
-  - python setup.py install  # test installation
+  - py.test --cov=nimfa
 
 after_success:
   - coveralls

--- a/nimfa/tests/__init__.py
+++ b/nimfa/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Various tests for nimfa code"""

--- a/nimfa/tests/test_examples.py
+++ b/nimfa/tests/test_examples.py
@@ -10,9 +10,11 @@ synthetic_runs = [getattr(synthetic, f) for f in dir(synthetic) if f.startswith(
 
 @pytest.mark.medium
 @pytest.mark.parametrize('synth_run', synthetic_runs)
-def test_synthetic(synth_run):
+def test_synthetic(synth_run, monkeypatch):
+    ran_funcs = []
     def check_synthetic_result(fit, idx=None):
         """Basic checks that synthetic results are 'Ok'"""
+        ran_funcs.append(1)
         # typically tests pass with > .75 but because of still present inherent
         # randomizations results vary. So to be on a safe side for now set a very
         # liberal threshold
@@ -25,12 +27,10 @@ def test_synthetic(synth_run):
     V = prng.rand(20, 30)
     V1 = prng.rand(20, 25)
 
-    try:
-        old_print_info = synthetic.print_info
-        synthetic.print_info = check_synthetic_result
-        if synth_run is getattr(synthetic, 'run_snmnmf'):
-            synth_run(V, V1)
-        else:
-            synth_run(V)
-    finally:
-        synthetic.print_info = old_print_info
+    monkeypatch.setattr(synthetic, 'print_info', check_synthetic_result)
+    if synth_run is getattr(synthetic, 'run_snmnmf'):
+        synth_run(V, V1)
+    else:
+        synth_run(V)
+    # for paranoid monkeypatching people, to make sure that the patch worked
+    assert ran_funcs != [], "we must have ran our check"

--- a/nimfa/tests/test_examples.py
+++ b/nimfa/tests/test_examples.py
@@ -1,0 +1,36 @@
+"""Test examples provided by nimfa"""
+
+import numpy as np
+
+from nimfa.examples import synthetic
+
+import pytest
+
+synthetic_runs = [getattr(synthetic, f) for f in dir(synthetic) if f.startswith('run_')]
+
+@pytest.mark.medium
+@pytest.mark.parametrize('synth_run', synthetic_runs)
+def test_synthetic(synth_run):
+    def check_synthetic_result(fit, idx=None):
+        """Basic checks that synthetic results are 'Ok'"""
+        # typically tests pass with > .75 but because of still present inherent
+        # randomizations results vary. So to be on a safe side for now set a very
+        # liberal threshold
+        # TODO:  make runs deterministic
+        assert fit.summary(idx)['evar'] > 0.62
+
+    # Setup data exactly the same way as in synthetic example
+    prng = np.random.RandomState(42)
+    # construct target matrices
+    V = prng.rand(20, 30)
+    V1 = prng.rand(20, 25)
+
+    try:
+        old_print_info = synthetic.print_info
+        synthetic.print_info = check_synthetic_result
+        if synth_run is getattr(synthetic, 'run_snmnmf'):
+            synth_run(V, V1)
+        else:
+            synth_run(V)
+    finally:
+        synthetic.print_info = old_print_info

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,3 @@
+# do not explicitly install base requirements via pip
+# -r requirements.txt
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+scipy

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27,py34
+
+[testenv]
+commands = py.test nimfa
+deps = -r{toxinidir}/requirements-tests.txt
+sitepackages = True
+
+[testenv:cover]
+commands = py.test --cov=nimfa


### PR DESCRIPTION
We with @ismav thought it wouldn't be nice if nimfa got some tests.  this PR is based on our previous one #27, so includes those commits as well.
To take advantage of it, you would need to enable travis-ci.org (very simple -- just login with github creds, enable toggle for this repo) and coveralls.io.  Then you could add their badges for convenience into the README.  Please don't hesitate to get in touch if you have any concerns.
Cheers